### PR TITLE
feat: add string literal tokenization

### DIFF
--- a/bin/monkey.ml
+++ b/bin/monkey.ml
@@ -2,6 +2,6 @@ open Monkey_lib
 include Lexer
 include Token
 
-let input = "let five = 5;"
+let input = "let hello_world = \"hello world\";"
 let tokens = Lexer.generate_tokens input |> List.map Token.token_to_string
 let () = tokens |> List.iter (fun token -> print_endline token)

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -3,6 +3,7 @@ type t =
   | EOF
   | IDENT of string
   | INT of string
+  | STRING of string
   | ASSIGN
   | PLUS
   | MINUS
@@ -43,6 +44,7 @@ let token_to_string = function
   | EOF -> "EOF"
   | IDENT a -> "IDENT " ^ a
   | INT a -> "INT " ^ a
+  | STRING a -> "STRING " ^ a
   | ASSIGN -> "ASSIGN"
   | PLUS -> "PLUS"
   | COMMA -> "COMMA"

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -6,6 +6,7 @@ type t =
 (* Identifiers and literals *)
 | IDENT of string
 | INT of string
+| STRING of string
 (* Operators *)
 | ASSIGN
 | PLUS

--- a/test/test.ml
+++ b/test/test.ml
@@ -26,6 +26,7 @@ let source_test_string =
    \t}\n\n\n\
    \t10 == 10;\n\
    \t10 != 9;\n\
+   \t\"string\";\n\
   \  "
 
 let source_test_expected =
@@ -109,6 +110,8 @@ let source_test_expected =
     Token.INT "10";
     Token.NOT_EQ;
     Token.INT "9";
+    Token.SEMICOLON;
+    Token.STRING "string";
     Token.SEMICOLON;
     (* sentinel *)
     Token.EOF;


### PR DESCRIPTION
Add support for string literals in the lexer:
- Add STRING token type to represent string literals
- Implement read_string function to handle content between quotes
- Update token_to_string to support STRING token display
- Add test cases for string literal tokenization

Example:
"hello world" is now correctly tokenized as STRING "hello world"